### PR TITLE
Ignore project.xcworkspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ActiveSupportKitPages/
+project.xcworkspace


### PR DESCRIPTION
Just a bit of cleanup so the project.xcworkspace doesn't show with "git status".
